### PR TITLE
fix rbenv-doctor path

### DIFF
--- a/_docs/installation/macos.md
+++ b/_docs/installation/macos.md
@@ -120,7 +120,7 @@ brew install rbenv
 rbenv init
 
 # 설치상태 검사
-curl -fsSL https://github.com/rbenv/rbenv-installer/raw/master/bin/rbenv-doctor | bash
+curl -fsSL https://github.com/rbenv/rbenv-installer/raw/main/bin/rbenv-doctor | bash
 ```
 
 <!--


### PR DESCRIPTION
fix github branch name of the rbenv-doctor from master to main